### PR TITLE
Feat: Support Persisted Queries 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ coverage
 
 # OS X
 .DS_Store
+
+# yalc
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "mercurius": "^12.2.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.1",
-    "mercurius": "file:.yalc/mercurius"
+    "fastify-plugin": "^4.5.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "mercurius": "^12.2.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.1"
+    "fastify-plugin": "^4.5.1",
+    "mercurius": "file:.yalc/mercurius"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -74,6 +74,7 @@ tap.test('schema validation', async t => {
     t.equal(res.statusCode, 400)
     t.strictSame(JSON.parse(res.body), expectedResult)
   })
+
   t.test('with a malformed Query', async t => {
     const app = Fastify()
     app.register(mercuriusDynamicSchema, {


### PR DESCRIPTION
Uses the extracted function in mercurius to avoid duplication of logic and only re-implements functions that now are needed for the same


Depends on https://github.com/mercurius-js/mercurius/pull/1078
Closes #4

## Pending 
- [ ] Probably also need persisted query per schema instead (needs to be discussed)
- [ ] Safe JSON instead of `JSON.parse` 
- [ ] Subscriptions 
- [ ] An easier way to delegate the whole thing (would need larger changes in mercurius)