### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "c8": "^9.0.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
-        "husky": "^9.0.6",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.2",
         "mercurius": "^14.0.0",
         "prettier": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:standard": "standard | snazzy",
     "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin index.test-d.ts",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "npm run test:unit && npm run test:types",
     "test:unit": "tap test/*.test.js && c8 report --check-coverage --temp-directory .tap/coverage --statements 97.67 --branches 85.71 --functions 100 --lines 97.67",
     "test:types": "tsd"
@@ -51,7 +51,7 @@
     "c8": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "husky": "^9.0.6",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.2",
     "mercurius": "^14.0.0",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)