### PR TITLE
chore: migrate to OIDC publishing for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       issues: write
@@ -25,13 +26,7 @@ jobs:
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
-          npm-token: >-
-            ${{ secrets[format('NPM_TOKEN_{0}', github.actor)] ||
-            secrets.NPM_TOKEN }}
-          optic-token: >-
-            ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] ||
-            secrets.OPTIC_TOKEN }}
+          publish-mode: oidc
           semver: ${{ github.event.inputs.semver }}
           commit-message: 'chore: release {version}'
           build-command: npm ci
-          provenance: true


### PR DESCRIPTION
- Add OIDC trusted publishing support
- Remove npm token and optic token dependencies
- Add production environment and required permissions
- Update to publish-mode: oidc

This migration eliminates the need for npm tokens and provides enhanced security through GitHub's identity provider.